### PR TITLE
Additional detail on attachment page

### DIFF
--- a/wp-content/themes/vanguard-history/template-parts/content-attachment.php
+++ b/wp-content/themes/vanguard-history/template-parts/content-attachment.php
@@ -54,6 +54,16 @@
 			);
 		}
 		?>
+		<pre>
+			<?php
+				// adding properties to post object
+				$post->{'year_object'} = get_the_terms(get_the_ID(), 'vhs_year');
+				$post->{'year'} = $post->{'year_object'}[0]->{'name'};
+				$post->{'ensemble_object'} = get_the_terms(get_the_ID(), 'ensemble');
+				echo $post->{'ensemble'} = $post->{'year_object'}[0]->{'name'};
+				print_r($post);
+			?>
+		</pre>
 	</div><!-- .entry-content -->
 
 	<footer class="entry-footer ui container">

--- a/wp-content/themes/vanguard-history/template-parts/content-attachment.php
+++ b/wp-content/themes/vanguard-history/template-parts/content-attachment.php
@@ -53,13 +53,6 @@
 				)
 			);
 		}
-		
-		wp_link_pages(
-			array(
-				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'vanguard-history' ),
-				'after'  => '</div>',
-			)
-		);
 		?>
 	</div><!-- .entry-content -->
 

--- a/wp-content/themes/vanguard-history/template-parts/content-attachment.php
+++ b/wp-content/themes/vanguard-history/template-parts/content-attachment.php
@@ -60,7 +60,11 @@
 				$post->{'year_object'} = get_the_terms(get_the_ID(), 'vhs_year');
 				$post->{'year'} = $post->{'year_object'}[0]->{'name'};
 				$post->{'ensemble_object'} = get_the_terms(get_the_ID(), 'ensemble');
-				echo $post->{'ensemble'} = $post->{'year_object'}[0]->{'name'};
+				$post->{'ensemble'} = $post->{'ensemble_object'}[0]->{'name'};
+				$post->{'creator_object'} = get_the_terms(get_the_ID(), 'creator_name');
+				$post->{'creator'} = $post->{'creator_object'}[0]->{'name'};
+				$post->{'submitter_object'} = get_the_terms(get_the_ID(), 'submitter_name');
+				$post->{'submitter'} = $post->{'submitter_object'}[0]->{'name'};
 				print_r($post);
 			?>
 		</pre>

--- a/wp-content/themes/vanguard-history/template-parts/content-attachment.php
+++ b/wp-content/themes/vanguard-history/template-parts/content-attachment.php
@@ -55,25 +55,49 @@
 		}
 		// adding properties to post object
 		$post->{'year_object'} = get_the_terms(get_the_ID(), 'vhs_year');
-		$post->{'year'} = $post->{'year_object'}[0]->{'name'};
+		$year = $post->{'year_object'}[0]->{'name'};
 		$post->{'ensemble_object'} = get_the_terms(get_the_ID(), 'ensemble');
-		$post->{'ensemble'} = $post->{'ensemble_object'}[0]->{'name'};
+		$ensemble = $post->{'ensemble_object'}[0]->{'name'};
 		$post->{'creator_object'} = get_the_terms(get_the_ID(), 'creator_name');
-		$post->{'creator'} = $post->{'creator_object'}[0]->{'name'};
+		$creator = $post->{'creator_object'}[0]->{'name'};
 		$post->{'submitter_object'} = get_the_terms(get_the_ID(), 'submitter_name');
-		$post->{'submitter'} = $post->{'submitter_object'}[0]->{'name'};
+		$submitter = $post->{'submitter_object'}[0]->{'name'};
 		?>
 
 		<div id="attachment-properties">
 			<?php
 			//displaying properties
-			if(!empty($post->{'year'}) || !empty($post->{'ensemble'})){
+			if(!empty($year) || !empty($ensemble)){
 				echo("
-					<div id='year-and-ensemble' class='attachment-property'>
-						$post->{'year'} $post->{'ensemble'}
+					<div id='year-and-ensemble' class='attachment-property attachment-property-group'>
+						<span id='year'>$year</span><span id='ensemble'>$ensemble</span>
 					</div>
 				");
 			}
+			//logic to include dl tag for creator and submitter
+			if(!empty($creator) || !empty($submitter)){
+				//open dl tag
+				echo("<dl id='creator and submitter'>");
+				if(!empty($creator)){
+					echo("
+						<div id='creator' class='attachment-property list-group'>
+							<dt>Created by</dt>
+							<dd>$creator</dd>
+						</div>
+					");
+				}
+				if(!empty($submitter)){
+					echo("
+						<div id='submitter' class='attachment-property list-group'>
+							<dt>Uploaded by</dt>
+							<dd>$submitter</dd>
+						</div>
+					");
+				}
+				// close dl tag
+				echo("</dl>");
+			}
+
 			?>
 		</div>
 	</div><!-- .entry-content -->

--- a/wp-content/themes/vanguard-history/template-parts/content-attachment.php
+++ b/wp-content/themes/vanguard-history/template-parts/content-attachment.php
@@ -53,21 +53,29 @@
 				)
 			);
 		}
+		// adding properties to post object
+		$post->{'year_object'} = get_the_terms(get_the_ID(), 'vhs_year');
+		$post->{'year'} = $post->{'year_object'}[0]->{'name'};
+		$post->{'ensemble_object'} = get_the_terms(get_the_ID(), 'ensemble');
+		$post->{'ensemble'} = $post->{'ensemble_object'}[0]->{'name'};
+		$post->{'creator_object'} = get_the_terms(get_the_ID(), 'creator_name');
+		$post->{'creator'} = $post->{'creator_object'}[0]->{'name'};
+		$post->{'submitter_object'} = get_the_terms(get_the_ID(), 'submitter_name');
+		$post->{'submitter'} = $post->{'submitter_object'}[0]->{'name'};
 		?>
-		<pre>
+
+		<div id="attachment-properties">
 			<?php
-				// adding properties to post object
-				$post->{'year_object'} = get_the_terms(get_the_ID(), 'vhs_year');
-				$post->{'year'} = $post->{'year_object'}[0]->{'name'};
-				$post->{'ensemble_object'} = get_the_terms(get_the_ID(), 'ensemble');
-				$post->{'ensemble'} = $post->{'ensemble_object'}[0]->{'name'};
-				$post->{'creator_object'} = get_the_terms(get_the_ID(), 'creator_name');
-				$post->{'creator'} = $post->{'creator_object'}[0]->{'name'};
-				$post->{'submitter_object'} = get_the_terms(get_the_ID(), 'submitter_name');
-				$post->{'submitter'} = $post->{'submitter_object'}[0]->{'name'};
-				print_r($post);
+			//displaying properties
+			if(!empty($post->{'year'}) || !empty($post->{'ensemble'})){
+				echo("
+					<div id='year-and-ensemble' class='attachment-property'>
+						$post->{'year'} $post->{'ensemble'}
+					</div>
+				");
+			}
 			?>
-		</pre>
+		</div>
 	</div><!-- .entry-content -->
 
 	<footer class="entry-footer ui container">


### PR DESCRIPTION
This shows all the properties I think we want to show on the media detail a.k.a. attachment page. I didn't deploy it anywhere since we have other things on dev and stage at the moment, but here's a screenshot. 
<img width="446" alt="Screen Shot 2023-01-31 at 9 42 15 PM" src="https://user-images.githubusercontent.com/2223603/215932457-cb318e59-ede8-496a-9206-38d83b2eb929.png">
